### PR TITLE
fix(accordion): correct icon change for open/close states

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                             <button type="button" onclick="toggleAccordion()"
                                 class="flex w-full justify-between rounded-lg bg-gray-700 px-4 py-3 text-right text-sm font-medium text-white hover:bg-gray-600 transition-colors">
                                 <span>راهنمای استفاده</span>
-                                <span class="accordion-icon">↓</span>
+                                <span class="accordion-icon"><i class="fa-solid fa-arrow-down"></i></span>
                             </button>
                             <div class="accordion-content hidden mt-2 px-4 py-3 text-sm text-gray-300 bg-gray-700 rounded-lg prose prose-invert">
                                 <h3 class="text-lg font-semibold mb-2"></h3>

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -341,13 +341,16 @@ async function takeHistoryScreenshot() {
 
 function toggleAccordion() {
     const content = document.querySelector('.accordion-content');
-    const header = document.querySelector('.accordion-header');
+    const icon = document.querySelector('.accordion-icon > i');
+    
     if (content.style.display === 'none' || !content.style.display) {
-        content.style.display = 'block';
-        header.innerHTML = 'راهنمای استفاده ↑';
+      // open state
+      content.style.display = 'block';
+      icon.style.transform = 'rotate(-180deg)';
     } else {
-        content.style.display = 'none';
-        header.innerHTML = 'راهنمای استفاده ↓';
+      // close state
+      content.style.display = 'none';
+      icon.style.transform = '';
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where the accordion open/close states displayed the same icon due to an error in the icon logic. 

**Changes:**
- Updated the icon logic to ensure the correct icon is displayed for both open and close states. (toggleAccordion)
- Added a new font-awesome arrow-down icon for better user interface.
